### PR TITLE
No admin required

### DIFF
--- a/installer/HYPAR-CustomRevitConverters.iss
+++ b/installer/HYPAR-CustomRevitConverters.iss
@@ -26,6 +26,8 @@ OutputDir=.
 OutputBaseFilename=HYPAR-CustomRevitConverters.v{#MyAppVersion}
 Compression=lzma
 SolidCompression=yes
+PrivilegesRequired=lowest
+UninstallFilesDir="{userpf}\Hypar\uninstall\revit-addin\uninstall"
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -37,10 +39,10 @@ Name: beamConverter; Description: Hypar Beam Converter;  Types: full
 
 [Files]
 ; Curtain Wall Converter Option
-Source: "C:\Users\johnpierson\Documents\Repos\HyparElementConverters\src\CurtainWall\HyparRevitCurtainWallConverter\bin\Debug\HyparRevitCurtainWallConverter.dll"; DestDir: "{#HyparConverterFolder}"; Flags: ignoreversion; Components: curtainWallConverter 
+Source: "..\src\CurtainWall\HyparRevitCurtainWallConverter\bin\Debug\HyparRevitCurtainWallConverter.dll"; DestDir: "{#HyparConverterFolder}"; Flags: ignoreversion; Components: curtainWallConverter
 
 ; Roof Converter Option
-Source: "C:\Users\johnpierson\Documents\Repos\HyparElementConverters\src\Roof\HyparRevitRoofConverter\bin\Debug\HyparRevitRoofConverter.dll"; DestDir: "{#HyparConverterFolder}"; Flags: ignoreversion; Components: roofConverter 
+Source: "..\src\Roof\HyparRevitRoofConverter\bin\Debug\HyparRevitRoofConverter.dll"; DestDir: "{#HyparConverterFolder}"; Flags: ignoreversion; Components: roofConverter
 
 ; Roof Converter Option
-Source: "C:\Users\johnpierson\Documents\Repos\HyparElementConverters\src\Beam\HyparRevitBeamConverter\bin\Debug\HyparRevitBeamConverter.dll"; DestDir: "{#HyparConverterFolder}"; Flags: ignoreversion; Components: beamConverter
+Source: "..\src\Beam\HyparRevitBeamConverter\bin\Debug\HyparRevitBeamConverter.dll"; DestDir: "{#HyparConverterFolder}"; Flags: ignoreversion; Components: beamConverter

--- a/installer/HYPAR-CustomRevitConverters.iss
+++ b/installer/HYPAR-CustomRevitConverters.iss
@@ -27,7 +27,7 @@ OutputBaseFilename=HYPAR-CustomRevitConverters.v{#MyAppVersion}
 Compression=lzma
 SolidCompression=yes
 PrivilegesRequired=lowest
-UninstallFilesDir="{userpf}\Hypar\uninstall\paralax-hypar-revit-converters\uninstall"
+UninstallFilesDir="{userpf}\Hypar\uninstall\parallax-hypar-revit-converters\uninstall"
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/installer/HYPAR-CustomRevitConverters.iss
+++ b/installer/HYPAR-CustomRevitConverters.iss
@@ -27,7 +27,7 @@ OutputBaseFilename=HYPAR-CustomRevitConverters.v{#MyAppVersion}
 Compression=lzma
 SolidCompression=yes
 PrivilegesRequired=lowest
-UninstallFilesDir="{userpf}\Hypar\uninstall\revit-addin\uninstall"
+UninstallFilesDir="{userpf}\Hypar\uninstall\paralax-hypar-revit-converters\uninstall"
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
Make it so that the installer doesn't require elevated permissions.  we only add files to AppData and we also make it so that the uninstaller goes somewhere that doesn't require elevated permissions.

Also made some paths relative just for convenience.